### PR TITLE
Required rspec to avoid NameError when running specs

### DIFF
--- a/lib/be_valid_asset/be_valid_base.rb
+++ b/lib/be_valid_asset/be_valid_base.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 
 module BeValidAsset
 


### PR DESCRIPTION
Added a small `require 'rspec'` to `be_valid_base.rb` in order to avoid the following error when running specs :

```
NameError: uninitialized constant BeValidAsset::RSpec
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/be_valid_asset-1.3.0/lib/be_valid_asset/be_valid_base.rb:4:in `<module:BeValidAsset>'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/be_valid_asset-1.3.0/lib/be_valid_asset/be_valid_base.rb:2:in `<top (required)>'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/be_valid_asset-1.3.0/lib/be_valid_asset.rb:3:in `<top (required)>'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler/runtime.rb:76:in `require'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler/runtime.rb:72:in `each'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler/runtime.rb:72:in `block in require'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler/runtime.rb:61:in `each'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler/runtime.rb:61:in `require'
/home/vagrant/.rvm/gems/ruby-2.1.1/gems/bundler-1.7.4/lib/bundler.rb:133:in `require'
```
